### PR TITLE
Empty Input Buffer in `add_doc()`

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -231,6 +231,7 @@ void doc()
 
 void add_doc()
 {
+    getchar();
     ofstream fout("Doctor", ios::out|ios::app|ios::binary);
 
     Doctor doc1;


### PR DESCRIPTION
- This is a temporary solution, need to find reason for non-empty buffer.
- We go from `home_sc()` to `doc()` to `add_doc()` , the input buffer gets a value in the function `add_doc()` as using `getchar()` does not work in `home_sc()` and `doc()`.